### PR TITLE
Correccion error al mostrar los items dentro de la side-bar

### DIFF
--- a/src/app/sidebar/sidebar.component.html
+++ b/src/app/sidebar/sidebar.component.html
@@ -1,10 +1,10 @@
 <div class="sidebar-container" [@sidebarAnimation]="sidebarAnimation">
-  <!-- <mat-nav-list role="list">
+  <mat-nav-list role="list">
     @for (item of navItems; track $index) {
-    <ng-uui-menu [item]="item"></ng-uui-menu>
+    <ng-uui-menu [item]="item" ></ng-uui-menu>
     }
-  </mat-nav-list>-->
-  <ul>
+  </mat-nav-list>
+  <!-- <ul>
     <li>
       <a routerLink="/datos/list-solicitudes-estudiante" routerLinkActive="active">list-solicitudes-estudiante</a>
     </li>
@@ -14,5 +14,5 @@
     <li>
       <a routerLink="/espacios-academicos" routerLinkActive="active">espacios-academicos</a>
     </li>
-  </ul>
+  </ul> -->
 </div>


### PR DESCRIPTION
En el componete side-bar.html se había comentado el for encargado de renderizar los ítems porveninetes de navItem los cuales son los que componen el menú y esto se había remplazado por 3 ítems quemados con las etiquetas ul y li.

![image](https://github.com/udistrital/core_mf_cliente/assets/90805689/6c98f3bb-fad4-44ae-a48c-9f90a700dcea)

Esto hacía que el menú se viera de esta forma:


https://github.com/udistrital/core_mf_cliente/assets/90805689/f1ec52ff-fd4f-4062-993c-f4b8fb5c2566


Para solucionarlo se descomento el for y con este cambio se volvieron a renderizar los ítems provenientes de navItem:

![image](https://github.com/udistrital/core_mf_cliente/assets/90805689/13b40ee4-0aa3-43c6-9060-32940cb6542b)

Con esto quedaría arreglado el problema y el menú se vería de la siguiente forma:


https://github.com/udistrital/core_mf_cliente/assets/90805689/39ada39e-f262-4c2d-9f5b-94e48d1030f9


