### PR TITLE
Feat: Se añade un evento personalizado para cerrar sesion.

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,6 +9,7 @@ import { fromEvent } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 import { getCookie } from './header/header.component';
 import { ControlSizeContainerService } from './services/controlSizeContainer.service';
+import { ImplicitAutenticationService } from './services/implicit_autentication.service';
 
 @Component({
   selector: 'core-mf',
@@ -26,7 +27,8 @@ export class AppComponent implements OnInit {
   constructor(
     private menuService: MenuService,
     private controlSizeContainerService: ControlSizeContainerService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private autenticacionService: ImplicitAutenticationService
   ) {
     singleSpaPropsSubject.subscribe((props) => {
       // TODO: Ver la manera de usar esta info que viene del root

--- a/src/app/services/implicit_autentication.service.ts
+++ b/src/app/services/implicit_autentication.service.ts
@@ -27,6 +27,8 @@ export class ImplicitAutenticationService {
   private logoutSubject = new BehaviorSubject('');
   public logout$ = this.logoutSubject.asObservable();
 
+  private eventoCerrarSesionRegistrado = false; // Bandera para rastrear el registro del evento
+
   httpOptions: any;
   constructor(private httpClient: HttpClient) {
     document.addEventListener('visibilitychange', () => {
@@ -35,7 +37,32 @@ export class ImplicitAutenticationService {
         this.autologout(expires);
       }
     });
+    this.añadirEventoParaCerrarSesion();
   }
+  
+  ngOnDestroy() {
+    this.removerEventoParaCerrarSesion();
+  }
+
+  private añadirEventoParaCerrarSesion() {
+    if (!this.eventoCerrarSesionRegistrado) {
+      window.addEventListener('cerrar-sesion-mf', this.handleCerrarSesion);
+      this.eventoCerrarSesionRegistrado = true; // Marcar el evento como registrado
+    }
+  }
+
+  private removerEventoParaCerrarSesion() {
+    if (this.eventoCerrarSesionRegistrado) {
+      window.removeEventListener('cerrar-sesion-mf', this.handleCerrarSesion);
+      this.eventoCerrarSesionRegistrado = false; // Marcar el evento como no registrado
+    }
+  }
+
+  private handleCerrarSesion = (event: Event) => {
+    const customEvent = event as CustomEvent;
+    this.logout('action-event');
+  };
+
   init(entorno: any): any {
     this.environment = entorno;
     const id_token = window.localStorage.getItem('id_token');


### PR DESCRIPTION
- Se añade un evento para cerrar sesion. 
En cualquier mf se puede cerrar sesion emitiendo el siguiente evento o instanciando esta funcion y luego invocandola.
```
cerrarSesion() {
    const event = new CustomEvent('cerrar-sesion-mf');
    window.dispatchEvent(event);
}
```
---
udistrital/sga_documentacion#509